### PR TITLE
Distance Field + other methods

### DIFF
--- a/flowcast/pipeline.py
+++ b/flowcast/pipeline.py
@@ -925,7 +925,7 @@ class Pipeline:
         self.bind_value(y, PipelineVariable.from_result(out_data, var))
 
     @compile
-    def mask_to_distance_field(self, y:ResultID, x:OperandID, /, include_initial_points:bool=False):
+    def mask_to_distance_field(self, y:ResultID, x:OperandID, /, include_initial_points:bool):
         """
         Convert a mask to a distance field. Distances are in kilometers
 
@@ -938,7 +938,7 @@ class Pipeline:
         var = self.get_value(x)
         mask = var.data
         assert mask.dtype == bool, f'Invalid input mask: {x}. Must be a boolean array'
-        distances = mask_to_sdf(mask)
+        distances = mask_to_sdf(mask, include_initial_points=include_initial_points)
         self.bind_value(y, PipelineVariable.from_result(distances, var))
             
 

--- a/flowcast/regrid.py
+++ b/flowcast/regrid.py
@@ -228,7 +228,8 @@ def regrid_1d(
     # hacky way to deal with nans not propagating correctly under mode aggregation
     # TODO: is this correct for nearest interpolation?
     if aggregation == RegridType.mode or aggregation == RegridType.nearest_or_mode:
-        old_data[~validmask] = float('-inf')
+        if not np.all(validmask):
+            old_data[~validmask] = float('-inf') #TODO: this line will fail on integer data. but validmask should be all True in that case, so probably no problem...
 
     #perform the regridding on the data, and replace any nans
     result = regrid_1d_reducer(old_data, overlaps, aggregation, low_memory)

--- a/flowcast/spacetime.py
+++ b/flowcast/spacetime.py
@@ -171,7 +171,7 @@ def points_to_mask(lats: np.ndarray, lons: np.ndarray, /, n_lat=180, n_lon=360, 
     return data
 
 from sklearn.neighbors import BallTree
-def mask_to_sdf(mask: xr.DataArray):
+def mask_to_sdf(mask: xr.DataArray, include_initial_points:bool=False) -> xr.DataArray:
     """Generate a distance field from points in a boolean mask"""
 
     # collect just the True the points from the mask (and convert to radians)
@@ -192,6 +192,9 @@ def mask_to_sdf(mask: xr.DataArray):
     sdf = tree.query(mesh)[0]
     sdf = sdf.reshape(*mesh_shape).T  # reshape and put lat as first dimension
     sdf *= 6371.0  # convert from radians to kilometers
+
+    if not include_initial_points:
+        sdf[points_x_idx, points_y_idx] = np.nan
 
     # create DataArray from the distance field
     data = xr.DataArray(sdf, dims=['lat', 'lon'], coords={'lat': mask.lat, 'lon': mask.lon})

--- a/flowcast/spacetime.py
+++ b/flowcast/spacetime.py
@@ -171,7 +171,7 @@ def points_to_mask(lats: np.ndarray, lons: np.ndarray, /, n_lat=180, n_lon=360, 
     return data
 
 from sklearn.neighbors import BallTree
-def mask_to_sdf(mask: xr.DataArray, include_initial_points:bool=False) -> xr.DataArray:
+def mask_to_sdf(mask: xr.DataArray, include_initial_points:bool) -> xr.DataArray:
     """Generate a distance field from points in a boolean mask"""
 
     # collect just the True the points from the mask (and convert to radians)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flowcast"
-version = "0.2.6"
+version = "0.3.0"
 description = "A framework for dynamically stringing together operations over gridded netcdf data, to create derived insights"
 authors = ["David Samson <david@jataware.com>"]
 license = "GPL-3.0-or-later"


### PR DESCRIPTION
Added the ability to create distance fields from boolean masks within a `pipeline`:
- `mask_to_distance_field`

Also added the following `pipeline` methods:
- `power`
- `sum_reduce`
- `mean_reduce`
- `min_reduce`
- `max_reduce`
- `std_reduce`
- `median_reduce`
- `scalar_add`
- `scalar_subtract`
- `scalar_multiply`
- `scalar_divide`
- `scalar_power`

Added `spacetime` methods to support `mask_to_distance_field`
- `points_to_mask`
- `mask_to_sdf`